### PR TITLE
Removes tensorboard from being hardcoded

### DIFF
--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -269,12 +269,6 @@ class EfficientDetModelSpec(object):
     config_callbacks = train_lib.get_callbacks(config.as_dict(), val_dataset)
     callbacks = config_callbacks + callbacks
 
-    tb_callback = tf.keras.callbacks.TensorBoard(
-        log_dir=self.config['model_dir'] or '/tmp/tensorboard/',
-        update_freq=self.config['steps_per_execution'] or '24',
-        profile_batch=2 if self.config['profile'] else 0)
-    
-    callbacks.append(tb_callback)
     print(f"Our callbacks are {callbacks}")
     
     model.fit(

--- a/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
+++ b/tensorflow_examples/lite/model_maker/core/task/model_spec/object_detector_spec.py
@@ -270,7 +270,7 @@ class EfficientDetModelSpec(object):
     callbacks = config_callbacks + callbacks
 
     print(f"Our callbacks are {callbacks}")
-    
+     
     model.fit(
         train_dataset,
         epochs=epochs,


### PR DESCRIPTION
Attempting to fix
```
 File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/ops/summary_ops_v2.py", line 93, in __exit__
    _summary_state.writer.flush()
AttributeError: 'NoneType' object has no attribute 'flush'
```